### PR TITLE
Conservar masa en S0 al limitar Qs e I

### DIFF
--- a/tank_model/model.py
+++ b/tank_model/model.py
@@ -39,7 +39,17 @@ class TankModel:
         # Exceso sobre capacidad S0
         excess = max(0.0, S0 - p.S0_max)
         Qs += excess
-        S0 = S0 - Qs - I
+
+        # Verificar si hay agua suficiente en S0 para Qs + I
+        total_out = Qs + I
+        if total_out > S0:
+            factor = S0 / total_out if total_out > 0 else 0.0
+            Qs *= factor
+            I *= factor
+            S0 = 0.0
+        else:
+            S0 = S0 - total_out
+
         S0 = max(0.0, S0)
 
         # Tanque S1 (no saturado)

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Asegurar que el paquete local esté en el path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tank_model.model import TankModel, ModelConfig
+from tank_model.parameters import Parameters
+from tank_model.states import States
+
+
+def test_mass_conservation_when_s0_insufficient():
+    params = Parameters(
+        S0_max=1000.0,
+        k_qs=0.8,
+        k_inf=0.5,
+        k_perc=0.0,
+        phi=0.0,
+        k_qf=0.0,
+        k_bf=0.0,
+        f_et0=0.0,
+        f_et1=0.0,
+        alpha=1.0,
+        beta=1.0,
+    )
+    cfg = ModelConfig(route=False)
+    init_states = States(S0=10.0)
+    model = TankModel(params, cfg, init_states)
+
+    res = model.step(P=0.0, PET=0.0)
+
+    assert np.isclose(res["Qs"] + res["I"], 10.0)
+    assert res["S0"] == 0.0


### PR DESCRIPTION
## Summary
- Asegura la conservación de masa en el tanque superficial ajustando Qs e I cuando la suma excede el almacenamiento disponible
- Añade prueba unitaria para verificar la conservación de masa con almacenamiento superficial insuficiente

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895411cde608325adb5fbe95be2c48b