### PR TITLE
Interpolate invalid forcings before tank model run

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Modelo hidrológico modular tipo "tanques" (3 compartimentos + enrutamiento Nash) para series horarias o diarias.
 - Unidades internas de **mm** (almacenamientos y flujos).
 - Entrada mínima: fecha, **P_mm**, **PET_mm** (se puede poner PET_mm=0).
+- Las columnas **P_mm** y **PET_mm** con valores `NaN` o negativos se reemplazan mediante interpolación lineal y se indica cuántos datos fueron corregidos.
 - Salida: dataframe con caudales y particiones; conversión a m³/s vía `to_discharge()`.
 
 ## Estructura

--- a/tank_model/model.py
+++ b/tank_model/model.py
@@ -85,6 +85,12 @@ class TankModel:
         for c in cols:
             if c not in df.columns:
                 raise ValueError(f"Falta columna {c}")
+        # Reemplazar valores NaN o negativos mediante interpolación
+        invalid_mask = df[cols].isna() | (df[cols] < 0)
+        invalid_count = int(invalid_mask.sum().sum())
+        if invalid_count > 0:
+            df[cols] = df[cols].mask(invalid_mask).interpolate(limit_direction="both")
+            print(f"Se interpolaron {invalid_count} valores inválidos en P_mm/PET_mm.")
         out = []
         for i in range(len(df)):
             rec = self.step(df.iloc[i]["P_mm"], df.iloc[i]["PET_mm"])


### PR DESCRIPTION
## Summary
- replace NaN or negative `P_mm`/`PET_mm` values with interpolated data and report how many were corrected
- document interpolation of invalid forcings in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895412e73a083259480c7453717b3d7