### PR TITLE
Add PET method dropdown in calibration notebook

### DIFF
--- a/notebooks/calibracion_y_analisis.ipynb
+++ b/notebooks/calibracion_y_analisis.ipynb
@@ -93,6 +93,7 @@
     "\n",
     "import pandas as pd\n",
     "import numpy as np\n",
+    "import ipywidgets as widgets\n",
     "from tank_model import TankModel, ModelConfig, nse, kge, bias_pct\n",
     "from tank_model.parameters import Parameters\n",
     "from tank_model.io import load_csv, subset_period, tag_hydrology\n",
@@ -100,7 +101,23 @@
     "\n",
     "# 1) Cargar datos\n",
     "df = load_csv('../data/example_forcing.csv')\n",
-    "df.head()\n"
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c728af8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Seleccionar método de PET\n",
+    "pet_method = widgets.Dropdown(\n",
+    "    options=['column','cenicafe','hargreaves'],\n",
+    "    value='column',\n",
+    "    description='PET method:'\n",
+    ")\n",
+    "pet_method"
    ]
   },
   {
@@ -131,12 +148,14 @@
     }
    ],
    "source": [
-    "\n",
-    "# 2) Asegurar PET con Cenicafé (si tienes Tmean_C y Rs_MJ_m2_d en tu CSV)\n",
-    "# df = ensure_pet(df, method='cenicafe', a=0.0135, b=17.78)\n",
-    "# Para el ejemplo ya existe PET_mm:\n",
-    "df = ensure_pet(df, method='column')\n",
-    "df[['P_mm','PET_mm']].plot(title='P y PET', figsize=(9,3))\n"
+    "# 2) Asegurar PET\n",
+    "kwargs = {}\n",
+    "if pet_method.value == 'cenicafe':\n",
+    "    kwargs = {'a': 0.0135, 'b': 17.78}\n",
+    "elif pet_method.value == 'hargreaves':\n",
+    "    kwargs = {}\n",
+    "df = ensure_pet(df, method=pet_method.value, **kwargs)\n",
+    "df[['P_mm','PET_mm']].plot(title='P y PET', figsize=(9,3))"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add ipywidgets import and dropdown to select PET method in `calibracion_y_analisis.ipynb`
- update PET assurance cell to pass selected method and manage parameters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68957f9fde548325b49b56154ad45926