### PR TITLE
Ensure PET coverage for new forcing datasets

### DIFF
--- a/notebooks/calibracion_y_analisis.ipynb
+++ b/notebooks/calibracion_y_analisis.ipynb
@@ -5,7 +5,7 @@
    "id": "59db0852",
    "metadata": {},
    "source": [
-    "# Calibración y análisis — Modelo de Tanques"
+    "# Calibraci\u00f3n y an\u00e1lisis \u2014 Modelo de Tanques"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "a6a69331",
    "metadata": {},
    "source": [
-    "## Preparación de datos\n"
+    "## Preparaci\u00f3n de datos\n"
    ]
   },
   {
@@ -104,7 +104,7 @@
     "import ipywidgets as widgets\n",
     "from tank_model import TankModel, ModelConfig, nse, kge, bias_pct\n",
     "from tank_model.parameters import Parameters\n",
-    "from tank_model.io import load_csv, subset_period, tag_hydrology\n",
+    "from tank_model.io import load_csv, subset_period, tag_hydrology, ensure_pet_coverage\n",
     "from tank_model.et import ensure_pet\n",
     "\n",
     "# Cargar datos\n",
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Seleccionar método de PET\n",
+    "# Seleccionar m\u00e9todo de PET\n",
     "pet_method = widgets.Dropdown(\n",
     "    options=['column','cenicafe','hargreaves'],\n",
     "    value='column',\n",
@@ -181,7 +181,7 @@
    "id": "2f050b9a",
    "metadata": {},
    "source": [
-    "## Calibración\n"
+    "## Calibraci\u00f3n\n"
    ]
   },
   {
@@ -226,8 +226,8 @@
    "id": "e48b689e",
    "metadata": {},
    "source": [
-    "### Registrar calibración y listar calibraciones recientes\n",
-    "A continuación se muestra cómo registrar una calibración en el archivo de log y consultar las últimas calibraciones registradas para una cuenca."
+    "### Registrar calibraci\u00f3n y listar calibraciones recientes\n",
+    "A continuaci\u00f3n se muestra c\u00f3mo registrar una calibraci\u00f3n en el archivo de log y consultar las \u00faltimas calibraciones registradas para una cuenca."
    ]
   },
   {
@@ -241,7 +241,7 @@
      "output_type": "stream",
      "text": [
       "Mejor NSE registrado: 0.926\n",
-      "Últimas calibraciones registradas:\n"
+      "\u00daltimas calibraciones registradas:\n"
      ]
     },
     {
@@ -334,20 +334,20 @@
     }
    ],
    "source": [
-    "# Registrar calibración en el log y listar calibraciones recientes\n",
+    "# Registrar calibraci\u00f3n en el log y listar calibraciones recientes\n",
     "from tank_model.calibration import random_search, list_recent_calibrations\n",
     "\n",
     "def make_model(p):\n",
     "    return TankModel(params=p, config=cfg)\n",
     "\n",
-    "# Para este ejemplo utilizamos la simulación previa como 'observada' con algo de ruido\n",
+    "# Para este ejemplo utilizamos la simulaci\u00f3n previa como 'observada' con algo de ruido\n",
     "q_obs = sim['Q_m3s'].values * (1 + np.random.normal(0, 0.1, size=len(sim)))\n",
     "\n",
-    "# Nombre de la cuenca para registrar la calibración\n",
+    "# Nombre de la cuenca para registrar la calibraci\u00f3n\n",
     "catchment_name = 'ExampleCuenca'\n",
     "log_path = '../data/calibrations_example.csv'\n",
     "\n",
-    "# Ejecutar búsqueda aleatoria y guardar en el log\n",
+    "# Ejecutar b\u00fasqueda aleatoria y guardar en el log\n",
     "best_p, best_score = random_search(\n",
     "    make_model,\n",
     "    df,\n",
@@ -359,9 +359,9 @@
     ")\n",
     "print(f'Mejor NSE registrado: {best_score:.3f}')\n",
     "\n",
-    "# Listar las 5 últimas calibraciones para esta cuenca\n",
+    "# Listar las 5 \u00faltimas calibraciones para esta cuenca\n",
     "df_recent = pd.DataFrame(list_recent_calibrations(catchment_name, n=5, log_path=log_path))\n",
-    "print('Últimas calibraciones registradas:')\n",
+    "print('\u00daltimas calibraciones registradas:')\n",
     "df_recent\n"
    ]
   },
@@ -370,8 +370,8 @@
    "id": "5daeead0",
    "metadata": {},
    "source": [
-    "## Simulación con calibración guardada\n",
-    "Aplicar una calibración guardada a un conjunto de forzantes distinto."
+    "## Simulaci\u00f3n con calibraci\u00f3n guardada\n",
+    "Aplicar una calibraci\u00f3n guardada a un conjunto de forzantes distinto."
    ]
   },
   {
@@ -383,7 +383,7 @@
     {
      "data": {
       "text/plain": [
-       "<Axes: title={'center': 'Caudal simulado con calibración guardada en nuevos forzantes'}, xlabel='date'>"
+       "<Axes: title={'center': 'Caudal simulado con calibraci\u00f3n guardada en nuevos forzantes'}, xlabel='date'>"
       ]
      },
      "execution_count": 11,
@@ -402,14 +402,17 @@
     }
    ],
    "source": [
-    "# Aplicar la calibración guardada a nuevos forzantes\n",
+    "# Aplicar la calibraci\u00f3n guardada a nuevos forzantes\n",
     "df_new = load_csv('../data/new_forcing.csv')\n",
     "from tank_model.calibration import run_with_saved_calibration\n",
     "\n",
-    "# Ejecutar el modelo con la última calibración registrada (ID por defecto)\n",
+    "# Asegurar PET en df_new\n",
+    "df_new = ensure_pet_coverage(df_new, df['PET_mm'])\n",
+    "\n",
+    "# Ejecutar el modelo con la \u00faltima calibraci\u00f3n registrada (ID por defecto)\n",
     "sim_new = run_with_saved_calibration(make_model, df_new, catchment_name=catchment_name, log_path=log_path)\n",
     "\n",
-    "sim_new[['Qout_mm']].plot(title='Caudal simulado con calibración guardada en nuevos forzantes', figsize=(9,3))\n"
+    "sim_new[['Qout_mm']].plot(title='Caudal simulado con calibraci\u00f3n guardada en nuevos forzantes', figsize=(9,3))\n"
    ]
   },
   {
@@ -417,7 +420,7 @@
    "id": "0bc706b2",
    "metadata": {},
    "source": [
-    "## Análisis\n"
+    "## An\u00e1lisis\n"
    ]
   },
   {
@@ -527,7 +530,7 @@
    ],
    "source": [
     "\n",
-    "# Análisis seco/húmedo y métricas por régimen\n",
+    "# An\u00e1lisis seco/h\u00famedo y m\u00e9tricas por r\u00e9gimen\n",
     "reg = tag_hydrology(df, col='P_mm', dry_q=0.25, wet_q=0.75)\n",
     "sim['regime'] = reg\n",
     "sim.groupby('regime')['Qout_mm'].describe()\n"
@@ -552,7 +555,7 @@
    ],
    "source": [
     "\n",
-    "# NSE/KGE por subperíodos (ejemplo sintético con obs = sim + ruido)\n",
+    "# NSE/KGE por subper\u00edodos (ejemplo sint\u00e9tico con obs = sim + ruido)\n",
     "obs = sim['Qout_mm'] * (1 + np.random.normal(0, 0.1, size=len(sim)))\n",
     "print('NSE total:', nse(obs, sim['Qout_mm']))\n",
     "for r in ['dry','normal','wet']:\n",
@@ -565,7 +568,7 @@
    "id": "dafcfad6",
    "metadata": {},
    "source": [
-    "### Comparación de caudal simulado vs observado\n"
+    "### Comparaci\u00f3n de caudal simulado vs observado\n"
    ]
   },
   {
@@ -597,7 +600,7 @@
    ],
    "source": [
     "\n",
-    "# Comparación caudal simulado vs observado\n",
+    "# Comparaci\u00f3n caudal simulado vs observado\n",
     "df_obs = load_csv('../data/example_discharge.csv')\n",
     "# Asegurar que la columna se llame 'Qobs_m3s'\n",
     "if 'Qobs_m3s' not in df_obs.columns:\n",


### PR DESCRIPTION
## Summary
- add `ensure_pet_coverage` helper to fill PET_mm by cycling calibration PET series
- safeguard analysis notebook by filling PET before running saved calibration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68958b31ef2883259a116dd0c6775e73