### PR TITLE
Agregar guía de instalación con Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Nuevas funcionalidades:
 - Interfaz gráfica (`scripts/gui_app.py`) basada en Tkinter/Matplotlib *(requiere `python3-tk`)*.
 - Ejemplo de uso reproducible y calibración en `scripts/example_run.py`.
 
+## Instalación
+
+### Entorno Conda
+
+Para crear y activar un entorno conda con las dependencias:
+
+```bash
+conda env create -f environment.yml
+conda activate tank_model
+```
+
+Opcionalmente, instala el paquete en modo editable:
+
+```bash
+pip install -e .
+```
+
 ## Estructura
 ```
 tank_model/

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - matplotlib
   - notebook
+  - ipywidgets
   - tk
   - pip
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy>=1.20
 pandas>=1.3
 matplotlib>=3.3
 notebook>=6.0
+ipywidgets
 nbformat


### PR DESCRIPTION
## Summary
- Documentar cómo crear y activar el entorno conda desde `environment.yml`
- Incluir instalación opcional del paquete en modo editable
- Añadir `ipywidgets` a los requerimientos del proyecto

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896522aa34c83258bf8e017b70e1228