### PR TITLE
feat: add error metric heatmap visualization

### DIFF
--- a/tank_model/__init__.py
+++ b/tank_model/__init__.py
@@ -2,6 +2,6 @@ from .model import TankModel, ModelConfig
 from .parameters import Parameters
 from .states import States
 from .routing import nash_cascade, to_discharge
-from .metrics import nse, kge, bias_pct
+from .metrics import nse, kge, bias_pct, plot_error_metrics_heatmap
 from .et import et_cenicafe, et_hargreaves, ensure_pet
 from .io import load_csv, write_csv, subset_period, resample_mean, tag_hydrology

--- a/tank_model/metrics.py
+++ b/tank_model/metrics.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 def nse(obs, sim):
     obs = np.asarray(obs, dtype=float)
@@ -21,3 +22,60 @@ def bias_pct(obs, sim):
     obs = np.asarray(obs, dtype=float)
     sim = np.asarray(sim, dtype=float)
     return 100.0 * (np.nansum(sim) - np.nansum(obs)) / np.nansum(obs)
+
+
+def plot_error_metrics_heatmap(obs, sim, ax=None, cmap="viridis"):
+    """Plot a heatmap with common error metrics.
+
+    The function computes NSE, KGE and percentage bias for the provided
+    observed and simulated series and displays them in a single-row
+    heatmap.  Each cell is annotated with the metric value so the user can
+    quickly read the numbers.
+
+    Parameters
+    ----------
+    obs, sim : array-like
+        Observed and simulated series.  They are converted to ``numpy``
+        arrays and may contain ``NaN`` values.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw the heatmap on.  If ``None`` a new figure and axes are
+        created.
+    cmap : str, optional
+        Name of the matplotlib colormap used for the heatmap.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes containing the heatmap so that callers can further
+        customise or save the figure.
+    """
+
+    obs = np.asarray(obs, dtype=float)
+    sim = np.asarray(sim, dtype=float)
+
+    metric_funcs = {
+        "NSE": nse,
+        "KGE": kge,
+        "Bias%": bias_pct,
+    }
+    labels = list(metric_funcs)
+    values = [metric_funcs[name](obs, sim) for name in labels]
+    data = np.array(values, dtype=float).reshape(1, -1)
+
+    if ax is None:
+        fig_width = 1.2 * data.shape[1]
+        _, ax = plt.subplots(figsize=(fig_width, 2))
+
+    im = ax.imshow(data, aspect="auto", cmap=cmap)
+    mid = (np.nanmax(data) + np.nanmin(data)) / 2
+
+    for j, val in enumerate(data[0]):
+        color = "white" if val < mid else "black"
+        ax.text(j, 0, f"{val:.3f}", ha="center", va="center", color=color)
+
+    ax.set_xticks(range(len(labels)))
+    ax.set_xticklabels(labels)
+    ax.set_yticks([])
+    ax.set_title("Error metrics")
+    plt.colorbar(im, ax=ax, label="Value")
+    return ax

--- a/tests/test_metrics_heatmap.py
+++ b/tests/test_metrics_heatmap.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+
+# Use a non-interactive backend for tests
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# Ensure local package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tank_model.metrics import plot_error_metrics_heatmap, nse
+
+
+def test_plot_error_metrics_heatmap_annotations():
+    obs = np.array([1.0, 2.0, 3.0])
+    sim = np.array([1.0, 2.0, 3.0])
+
+    ax = plot_error_metrics_heatmap(obs, sim)
+
+    assert ax is not None
+    nse_val = nse(obs, sim)
+    texts = [t.get_text() for t in ax.texts]
+    assert any(f"{nse_val:.3f}" == txt for txt in texts)
+
+    plt.close(ax.figure)


### PR DESCRIPTION
## Summary
- add `plot_error_metrics_heatmap` to visualize NSE, KGE and bias as an annotated heatmap
- expose new plotting helper in public API
- test heatmap creation and annotation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689657a7f060832586a362f381a4f2c2