### PR TITLE
Require explicit basin area in ModelConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Modelo hidrológico modular tipo "tanques" (3 compartimentos + enrutamiento Nash
 - Las columnas **P_mm** y **PET_mm** con valores `NaN` o negativos se reemplazan mediante interpolación lineal y se indica cuántos datos fueron corregidos.
 - Salida: dataframe con caudales y particiones; conversión a m³/s vía `to_discharge()`.
 
+Al construir `ModelConfig` es obligatorio especificar el área real de la cuenca
+en kilómetros cuadrados mediante `area_km2`; no se asume un valor por defecto y
+se lanzará una excepción si permanece en `1.0`.
+
 Nuevas funcionalidades:
 - Soporte ampliado de **PET** para conjuntos de datos con temperatura, radiación y métodos empíricos (p. ej. Hamon, Hargreaves).
 - Módulos de calibración (`tank_model/calibration.py`) con búsqueda aleatoria y registro en `logs/`.

--- a/tank_model/model.py
+++ b/tank_model/model.py
@@ -8,9 +8,15 @@ from .routing import nash_cascade
 
 @dataclass
 class ModelConfig:
+    area_km2: float            # para conversión a m3/s
     dt_hours: float = 24.0     # 1 día por defecto
-    area_km2: float = 1.0      # para conversión a m3/s (opcional)
     route: bool = True         # aplicar Nash en la salida
+
+    def __post_init__(self):
+        if self.area_km2 == 1.0:
+            raise ValueError(
+                "Debe proporcionar el área real en km² al construir ModelConfig."
+            )
 
 class TankModel:
     def __init__(self, params: Parameters, config: ModelConfig, init_states: States = None):

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -25,7 +25,7 @@ def test_mass_conservation_when_s0_insufficient():
         alpha=1.0,
         beta=1.0,
     )
-    cfg = ModelConfig(route=False)
+    cfg = ModelConfig(area_km2=1.5, route=False)
     init_states = States(S0=10.0)
     model = TankModel(params, cfg, init_states)
 


### PR DESCRIPTION
## Summary
- Require the catchment area when instantiating `ModelConfig` and reject default value `1.0`
- Document in README that a real `area_km2` must be provided
- Update unit test to supply explicit area

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689657b9e79083259957120d817ec509