### PR TITLE
Update calibration notebook for fixed PET method and dataset split

### DIFF
--- a/notebooks/calibracion_y_analisis.ipynb
+++ b/notebooks/calibracion_y_analisis.ipynb
@@ -26,15 +26,14 @@
     "\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "import ipywidgets as widgets\n",
     "from tank_model import TankModel, ModelConfig, nse, kge, bias_pct\n",
     "from tank_model.parameters import Parameters\n",
     "from tank_model.io import load_csv, subset_period, tag_hydrology, ensure_pet_coverage\n",
     "from tank_model.et import ensure_pet\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# Cargar datos\n",
-    "df = load_csv('../data/example_forcing.csv')\n",
+    "# Cargar datos de prueba (1950-2017)\n",
+    "df = load_csv('../data/Datos_pruba_2.csv')\n",
     "df.head()"
    ]
   },
@@ -45,13 +44,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Seleccionar método de PET\n",
-    "pet_method = widgets.Dropdown(\n",
-    "    options=['column','cenicafe','hargreaves'],\n",
-    "    value='column',\n",
-    "    description='PET method:'\n",
-    ")\n",
-    "pet_method"
+    "# Seleccionar método de PET (opciones: 'column', 'cenicafe', 'hargreaves')\n",
+    "pet_method = 'column'  # lectura de PET desde la tabla\n"
    ]
   },
   {
@@ -67,19 +61,40 @@
     "    'cenicafe': ['Tmean_C', 'Rs_MJ_m2_d'],\n",
     "    'hargreaves': ['Tmean_C', 'Tmax_C', 'Tmin_C', 'Ra_MJ_m2_d'],\n",
     "}\n",
-    "if pet_method.value == 'cenicafe':\n",
+    "if pet_method == 'cenicafe':\n",
     "    df_med = load_csv('../data/medellin_pet_inputs.csv')\n",
     "    df_med_pet = ensure_pet(df_med, method='cenicafe', a=0.0135, b=17.78)\n",
     "    df['PET_mm'] = df_med_pet['PET_mm'].reindex(df.index)\n",
     "else:\n",
-    "    missing = [c for c in required.get(pet_method.value, []) if c not in df.columns]\n",
+    "    missing = [c for c in required.get(pet_method, []) if c not in df.columns]\n",
     "    if missing:\n",
-    "        print(f\"Se omite ensure_pet: faltan columnas {missing}\")\n",
+    "        print(f'Se omite ensure_pet: faltan columnas {missing}')\n",
     "    else:\n",
-    "        df = ensure_pet(df, method=pet_method.value)\n",
+    "        df = ensure_pet(df, method=pet_method)\n",
     "\n",
     "df[['P_mm','PET_mm']].plot(title='P y PET', figsize=(9,3))\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Dividir serie en calibración y validación\n",
+    "calib_frac = 0.7  # proporción de datos para calibración\n",
+    "split_date = None  # e.g., '1980-12-31' para dividir por fecha\n",
+    "\n",
+    "if split_date:\n",
+    "    df_calib = df.loc[:split_date]\n",
+    "    df_valid = df.loc[split_date:]\n",
+    "else:\n",
+    "    split_idx = int(len(df) * calib_frac)\n",
+    "    df_calib = df.iloc[:split_idx]\n",
+    "    df_valid = df.iloc[split_idx:]\n",
+    "# número de filas para calibración (útil más adelante)\n",
+    "split_idx = len(df_calib)\n"
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -98,7 +113,7 @@
    "source": [
     "\n",
     "# Configurar y correr\n",
-    "cfg = ModelConfig(dt_hours=24.0, area_km2=5.0, route=True)\n",
+    "cfg = ModelConfig(dt_hours=24.0, area_km2=0.173, route=True)  # área de cuenca 0.173 km²\n",
     "p = Parameters()\n",
     "m = TankModel(p, cfg)\n",
     "sim = m.run(df)\n",
@@ -121,7 +136,7 @@
     "# Mostrar leyendas de ambos ejes\n",
     "ax1.legend(loc='upper left')\n",
     "ax2.legend(loc='upper right')\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {
@@ -146,8 +161,10 @@
     "def make_model(p):\n",
     "    return TankModel(params=p, config=cfg)\n",
     "\n",
-    "# Para este ejemplo utilizamos la simulación previa como 'observada' con algo de ruido\n",
+    "# Serie observada sintética basada en la simulación previa\n",
     "q_obs = sim['Q_m3s'].values * (1 + np.random.normal(0, 0.1, size=len(sim)))\n",
+    "q_obs_calib = q_obs[:split_idx]\n",
+    "q_obs_valid = q_obs[split_idx:]\n",
     "\n",
     "# Nombre de la cuenca para registrar la calibración\n",
     "catchment_name = 'ExampleCuenca'\n",
@@ -156,14 +173,19 @@
     "# Ejecutar búsqueda aleatoria y guardar en el log\n",
     "best_p, best_score = random_search(\n",
     "    make_model,\n",
-    "    df,\n",
-    "    q_obs,\n",
+    "    df_calib,\n",
+    "    q_obs_calib,\n",
     "    n_iter=20,\n",
     "    seed=123,\n",
     "    catchment_name=catchment_name,\n",
     "    log_path=log_path,\n",
     ")\n",
     "print(f'Mejor NSE registrado: {best_score:.3f}')\n",
+    "\n",
+    "# Evaluar con la serie de validación\n",
+    "model_val = make_model(best_p)\n",
+    "sim_val = model_val.run(df_valid)\n",
+    "print('NSE en validación:', nse(q_obs_valid, sim_val['Q_m3s'].values))\n",
     "\n",
     "# Listar las 5 últimas calibraciones para esta cuenca\n",
     "df_recent = pd.DataFrame(list_recent_calibrations(catchment_name, n=5, log_path=log_path))\n",


### PR DESCRIPTION
## Summary
- Use 1950-2017 test dataset in calibration notebook
- Replace PET method widget with default string option and document alternatives
- Split forcing data into calibration and validation subsets with optional date cutoff and report validation NSE

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adfc5cda088325833402d6a8e6e858