### PR TITLE
Rename model flow outputs and update diagnostics

### DIFF
--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -31,5 +31,5 @@ def test_mass_conservation_when_s0_insufficient():
 
     res = model.step(P=0.0, PET=0.0)
 
-    assert np.isclose(res["Qs"] + res["I"], 10.0)
+    assert np.isclose(res["Qs_mm"] + res["I_mm"], 10.0)
     assert res["S0"] == 0.0


### PR DESCRIPTION
## Summary
- rename `step` flow outputs to `*_mm` names
- include `ET_mm` and `I_mm` in diagnostics optional terms
- compute water balance using ET and print accumulated ET in diagnostics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b4318dc83258edda72b3e52d1a7