### PR TITLE
Fix random_search flow extraction and add unit test

### DIFF
--- a/tank_model/calibration.py
+++ b/tank_model/calibration.py
@@ -67,11 +67,10 @@ def random_search(model_factory, df, q_obs, n_iter=200, seed=42, bounds=None,
             else:
                 setattr(p, k, rng.uniform(lo, hi))
         m = model_factory(p)
-        sim = m.run(df)["Q_m3s"].values
-        # score = kge(q_obs, sim)
+        sim_df = m.run(df)
+        q_sim = sim_df["Q_m3s"].values
+        # score = kge(q_obs, q_sim)
 
-        # dentro del loop de calibración
-        q_sim = sim["Q_m3s"].values
         nse_lin = nse(q_obs, q_sim)
         nse_log = nse(np.log1p(q_obs), np.log1p(q_sim))  # sensibilidad a bajos-medios
         # error de picos (top 1% observado)

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Ensure local package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tank_model.calibration import random_search
+from tank_model.model import TankModel, ModelConfig
+
+
+def model_factory(params):
+    cfg = ModelConfig(area_km2=10.0)
+    return TankModel(params, cfg)
+
+
+def test_random_search_returns_finite_score():
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({
+        "P_mm": rng.random(30),
+        "PET_mm": rng.random(30)
+    })
+    q_obs = rng.random(30)
+
+    best_params, best_score = random_search(model_factory, df, q_obs, n_iter=5, seed=0)
+    assert best_params is not None
+    assert np.isfinite(best_score)


### PR DESCRIPTION
## Summary
- Ensure `random_search` uses the DataFrame from `model.run` and extracts discharge series correctly
- Add unit test verifying `random_search` runs on synthetic data and returns a finite score

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b456c6c8325af8a7c2f237bc813